### PR TITLE
Move to from methods

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -31,6 +31,10 @@
       "affiliation": "The Ohio State University"
     },
     {
+      "name": "Anders Christian Mathisen",
+      "affiliation": "Norwegian University of Science and Technology"
+    },
+    {
       "name": "Simon Høgås"
     },
     {

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,10 @@ Unreleased
 
 Added
 -----
+- ``Rotation`` class methods ``from_neo_euler()``, ``from_axes_angles()``,
+  ``from_euler()``, ``from_matrix()``, ``random()`` and ``identity()`` and methods
+  ``to_euler()`` and ``to_matrix()`` are now available from the ``Quaternion`` class as
+  well.
 
 Changed
 -------

--- a/orix/__init__.py
+++ b/orix/__init__.py
@@ -12,6 +12,7 @@ __credits__ = [
     "Duncan Johnstone",
     "Niels Cautaerts",
     "Austin Gerlt",
+    "Anders Christian Mathisen",
     "Simon Høgås",
     "Alexander Clausen",
 ]

--- a/orix/quaternion/quaternion.py
+++ b/orix/quaternion/quaternion.py
@@ -189,7 +189,7 @@ class Quaternion(Object3d):
 
         Returns
         -------
-        quat
+        q
             Quaternions resulting from the triple cross product.
         """
         q1a, q1b, q1c, q1d = q1.a, q1.b, q1.c, q1.d
@@ -229,8 +229,240 @@ class Quaternion(Object3d):
             + q3a * q2b * q1c
         )
         # fmt: on
-        quat = cls(np.vstack((a, b, c, d)).T)
-        return quat
+        q = cls(np.vstack((a, b, c, d)).T)
+        return q
+
+    @classmethod
+    def from_neo_euler(cls, neo_euler: "NeoEuler") -> Quaternion:
+        """Create unit quaternion(s) from a neo-euler (vector)
+        representation.
+
+        Parameters
+        ----------
+        neo_euler
+            Vector parametrization of quaternions.
+
+        Returns
+        -------
+        q
+            Unit quaternion(s).
+        """
+        s = np.sin(neo_euler.angle / 2)
+        a = np.cos(neo_euler.angle / 2)
+        b = s * neo_euler.axis.x
+        c = s * neo_euler.axis.y
+        d = s * neo_euler.axis.z
+        q = cls(np.stack([a, b, c, d], axis=-1)).unit
+        return q
+
+    @classmethod
+    def from_axes_angles(
+        cls,
+        axes: Union[np.ndarray, Vector3d, tuple, list],
+        angles: Union[np.ndarray, tuple, list],
+    ) -> Quaternion:
+        """Create unit quaternion(s) from axis-angle pair(s).
+
+        Parameters
+        ----------
+        axes
+            Rotation axes.
+        angles
+            Rotation angles in radians.
+
+        Returns
+        -------
+        q
+            Unit quaternions.
+
+        Examples
+        --------
+        >>> from orix.quaternion import Quaternion
+        >>> q = Quaternion.from_axes_angles((0, 0, -1), np.pi / 2)
+        >>> q
+        Quaternion (1,)
+        [[ 0.7071  0.      0.     -0.7071]]
+
+        See Also
+        --------
+        from_neo_euler
+        """
+        axangle = AxAngle.from_axes_angles(axes, angles)
+        q = cls.from_neo_euler(axangle).unit
+        return q
+
+    # TODO: Remove decorator, **kwargs, and use of "convention" in 1.0
+    @classmethod
+    @deprecated_argument("convention", "0.9", "1.0", "direction")
+    def from_euler(
+        cls,
+        euler: Union[np.ndarray, tuple, list],
+        direction: str = "lab2crystal",
+        **kwargs,
+    ) -> Quaternion:
+        """Create unit quaternion(s) from Euler angle set(s) in radians
+        :cite:`rowenhorst2015consistent`.
+
+        Parameters
+        ----------
+        euler
+            Euler angles in radians in the Bunge convention.
+        direction
+            Direction of the transformation, either ``"lab2crystal"``
+            (default) or the inverse, ``"crystal2lab"``. The former is
+            the Bunge convention. Passing ``"MTEX"`` equals the latter.
+
+        Returns
+        -------
+        q
+            Unit quaternions.
+        """
+        direction = direction.lower()
+        if direction == "mtex" or (
+            "convention" in kwargs and kwargs["convention"] == "mtex"
+        ):
+            # MTEX' rotations are transformations from the crystal to
+            # the lab reference frames. See
+            # https://mtex-toolbox.github.io/MTEXvsBungeConvention.html
+            # and orix issue #215
+            direction = "crystal2lab"
+
+        directions = ["lab2crystal", "crystal2lab"]
+
+        # processing directions
+        if direction not in directions:
+            raise ValueError(
+                f"The chosen direction is not one of the allowed options {directions}"
+            )
+
+        eu = np.asarray(euler)
+        if np.any(np.abs(eu) > 4 * np.pi):
+            warnings.warn(
+                "Angles are assumed to be in radians, but degrees might have been "
+                "passed."
+            )
+        n = eu.shape[:-1]
+        alpha, beta, gamma = eu[..., 0], eu[..., 1], eu[..., 2]
+
+        # Uses A.5 & A.6 from Modelling Simul. Mater. Sci. Eng. 23
+        # (2015) 083501
+        sigma = 0.5 * np.add(alpha, gamma)
+        delta = 0.5 * np.subtract(alpha, gamma)
+        c = np.cos(beta / 2)
+        s = np.sin(beta / 2)
+
+        # Using P = 1 from A.6
+        q = np.zeros(n + (4,))
+        q[..., 0] = c * np.cos(sigma)
+        q[..., 1] = -s * np.cos(delta)
+        q[..., 2] = -s * np.sin(delta)
+        q[..., 3] = -c * np.sin(sigma)
+
+        for i in [1, 2, 3, 0]:  # Flip the zero element last
+            q[..., i] = np.where(q[..., 0] < 0, -q[..., i], q[..., i])
+
+        q = cls(q).unit
+
+        if direction == "crystal2lab":
+            q = ~q
+
+        return q
+
+    @classmethod
+    def from_matrix(cls, matrix: Union[np.ndarray, tuple, list]) -> Quaternion:
+        """Create unit quaternions from the orientation matrices
+        :cite:`rowenhorst2015consistent`.
+
+        Parameters
+        ----------
+        matrix
+            Sequence of orientation matrices with the last two
+            dimensions of shape ``(3, 3)``.
+
+        Returns
+        -------
+        q
+            Unit quaternions.
+
+        Examples
+        --------
+        >>> from orix.quaternion import Quaternion
+        >>> q = Quaternion.from_matrix([np.eye(3), 2 * np.eye(3), np.diag([1, -1, -1])])
+        >>> q
+        Quaternion (2,)
+        [[1. 0. 0. 0.]
+         [1. 0. 0. 0.]
+         [0. 1. 0. 0.]]
+        """
+        om = np.asarray(matrix)
+        # Assuming (3, 3) as last two dims
+        n = (1,) if om.ndim == 2 else om.shape[:-2]
+        q = np.zeros(n + (4,))
+
+        # Compute quaternion components
+        q0_almost = 1 + om[..., 0, 0] + om[..., 1, 1] + om[..., 2, 2]
+        q1_almost = 1 + om[..., 0, 0] - om[..., 1, 1] - om[..., 2, 2]
+        q2_almost = 1 - om[..., 0, 0] + om[..., 1, 1] - om[..., 2, 2]
+        q3_almost = 1 - om[..., 0, 0] - om[..., 1, 1] + om[..., 2, 2]
+        q[..., 0] = 0.5 * np.sqrt(np.where(q0_almost < _FLOAT_EPS, 0, q0_almost))
+        q[..., 1] = 0.5 * np.sqrt(np.where(q1_almost < _FLOAT_EPS, 0, q1_almost))
+        q[..., 2] = 0.5 * np.sqrt(np.where(q2_almost < _FLOAT_EPS, 0, q2_almost))
+        q[..., 3] = 0.5 * np.sqrt(np.where(q3_almost < _FLOAT_EPS, 0, q3_almost))
+
+        # Modify component signs if necessary
+        q[..., 1] = np.where(om[..., 2, 1] < om[..., 1, 2], -q[..., 1], q[..., 1])
+        q[..., 2] = np.where(om[..., 0, 2] < om[..., 2, 0], -q[..., 2], q[..., 2])
+        q[..., 3] = np.where(om[..., 1, 0] < om[..., 0, 1], -q[..., 3], q[..., 3])
+
+        q = cls(q).unit
+
+        return q
+
+    @classmethod
+    def random(cls, shape: Union[int, tuple] = (1,)) -> Quaternion:
+        """Return random quaternions.
+
+        Parameters
+        ----------
+        shape
+            Shape of the quaternion instance.
+
+        Returns
+        -------
+        q
+            Unit quaternions.
+        """
+        shape = (shape,) if isinstance(shape, int) else shape
+        n = int(np.prod(shape))
+        q = []
+        while len(q) < n:
+            r = np.random.uniform(-1, 1, (3 * n, cls.dim))
+            r2 = np.sum(np.square(r), axis=1)
+            r = r[np.logical_and(1e-9**2 < r2, r2 <= 1)]
+            q += list(r)
+        q = cls(np.array(q[:n]))
+        q = q.unit
+        q = q.reshape(*shape)
+        return q
+
+    @classmethod
+    def identity(cls, shape: Union[int, tuple] = (1,)) -> Quaternion:
+        """Return identity quaternions.
+
+        Parameters
+        ----------
+        shape
+            Shape of the quaternion instance.
+
+        Returns
+        -------
+        q
+            Identity quaternions.
+        """
+        shape = (shape,) if isinstance(shape, int) else shape
+        q = np.zeros(shape + (4,))
+        q[..., 0] = 1
+        return cls(q)
 
     def dot(self, other: Quaternion) -> np.ndarray:
         """Return the dot products of the quaternions and the other
@@ -254,9 +486,9 @@ class Quaternion(Object3d):
         Examples
         --------
         >>> from orix.quaternion import Quaternion
-        >>> quat1 = Quaternion([[1, 0, 0, 0], [0.9239, 0, 0, 0.3827]])
-        >>> quat2 = Quaternion([[0.9239, 0, 0, 0.3827], [0.7071, 0, 0, 0.7071]])
-        >>> quat1.dot(quat2)
+        >>> q1 = Quaternion([[1, 0, 0, 0], [0.9239, 0, 0, 0.3827]])
+        >>> q2 = Quaternion([[0.9239, 0, 0, 0.3827], [0.7071, 0, 0, 0.7071]])
+        >>> q1.dot(q2)
         array([0.9239    , 0.92389686])
         """
         return np.sum(self.data * other.data, axis=-1)
@@ -283,9 +515,9 @@ class Quaternion(Object3d):
         Examples
         --------
         >>> from orix.quaternion import Quaternion
-        >>> quat1 = Quaternion([[1, 0, 0, 0], [0.9239, 0, 0, 0.3827]])
-        >>> quat2 = Quaternion([[0.9239, 0, 0, 0.3827], [0.7071, 0, 0, 0.7071]])
-        >>> quat1.dot_outer(quat2)
+        >>> q1 = Quaternion([[1, 0, 0, 0], [0.9239, 0, 0, 0.3827]])
+        >>> q2 = Quaternion([[0.9239, 0, 0, 0.3827], [0.7071, 0, 0, 0.7071]])
+        >>> q1.dot_outer(q2)
         array([[0.9239    , 0.7071    ],
                [1.0000505 , 0.92389686]])
         """
@@ -387,6 +619,121 @@ class Quaternion(Object3d):
                 "This operation is currently not avaliable in orix, please use outer "
                 "with `other` of type `Quaternion` or `Vector3d`"
             )
+
+    # TODO: Remove decorator and **kwargs in 1.0
+    @deprecated_argument("convention", since="0.9", removal="1.0")
+    def to_euler(self, **kwargs) -> np.ndarray:
+        r"""Return the normalized quaternions as Euler angles in the
+        Bunge convention :cite:`rowenhorst2015consistent`.
+
+        Returns
+        -------
+        eu
+            Array of Euler angles in radians, in the ranges
+            :math:`\phi_1 \in [0, 2\pi]`, :math:`\Phi \in [0, \pi]`, and
+            :math:`\phi_1 \in [0, 2\pi]`.
+        """
+        # A.14 from Modelling Simul. Mater. Sci. Eng. 23 (2015) 083501
+        n = self.data.shape[:-1]
+        eu = np.zeros(n + (3,))
+
+        q = self.unit
+        a, b, c, d = q.a, q.b, q.c, q.d
+
+        q03 = a**2 + d**2
+        q12 = b**2 + c**2
+        chi = np.sqrt(q03 * q12)
+
+        # P = 1
+
+        q12_is_zero = q12 == 0
+        if np.sum(q12_is_zero) > 0:
+            alpha = np.arctan2(-2 * a * d, a**2 - d**2)
+            eu[..., 0] = np.where(q12_is_zero, alpha, eu[..., 0])
+            eu[..., 1] = np.where(q12_is_zero, 0, eu[..., 1])
+            eu[..., 2] = np.where(q12_is_zero, 0, eu[..., 2])
+
+        q03_is_zero = q03 == 0
+        if np.sum(q03_is_zero) > 0:
+            alpha = np.arctan2(2 * b * c, b**2 - c**2)
+            eu[..., 0] = np.where(q03_is_zero, alpha, eu[..., 0])
+            eu[..., 1] = np.where(q03_is_zero, np.pi, eu[..., 1])
+            eu[..., 2] = np.where(q03_is_zero, 0, eu[..., 2])
+
+        if np.sum(chi != 0) > 0:
+            not_zero = ~np.isclose(chi, 0)
+            alpha = np.arctan2(
+                np.divide(
+                    b * d - a * c, chi, where=not_zero, out=np.full_like(chi, np.inf)
+                ),
+                np.divide(
+                    -a * b - c * d, chi, where=not_zero, out=np.full_like(chi, np.inf)
+                ),
+            )
+            beta = np.arctan2(2 * chi, q03 - q12)
+            gamma = np.arctan2(
+                np.divide(
+                    a * c + b * d, chi, where=not_zero, out=np.full_like(chi, np.inf)
+                ),
+                np.divide(
+                    c * d - a * b, chi, where=not_zero, out=np.full_like(chi, np.inf)
+                ),
+            )
+            eu[..., 0] = np.where(not_zero, alpha, eu[..., 0])
+            eu[..., 1] = np.where(not_zero, beta, eu[..., 1])
+            eu[..., 2] = np.where(not_zero, gamma, eu[..., 2])
+
+        # Reduce Euler angles to definition range
+        eu[np.abs(eu) < _FLOAT_EPS] = 0
+        eu = np.where(eu < 0, np.mod(eu + 2 * np.pi, (2 * np.pi, np.pi, 2 * np.pi)), eu)
+
+        return eu
+
+    def to_matrix(self) -> np.ndarray:
+        """Return the normalized quaternions as orientation matrices
+        :cite:`rowenhorst2015consistent`.
+
+        Returns
+        -------
+        om
+            Array of orientation matrices after normalizing the
+            quaternions.
+
+        Examples
+        --------
+        >>> from orix.quaternion import Quaternion
+        >>> q1 = Quaternion([[1, 0, 0, 0], [2, 0, 0, 0]])
+        >>> np.allclose(q1.to_matrix(), np.eye(3))
+        True
+        >>> q2 = Quaternion([[0, 1, 0, 0], [0, 2, 0, 0]])
+        >>> np.allclose(q2.to_matrix(), np.diag([1, -1, -1]))
+        True
+        """
+        q = self.unit
+        a, b, c, d = q.a, q.b, q.c, q.d
+        om = np.zeros(self.shape + (3, 3))
+
+        bb = b**2
+        cc = c**2
+        dd = d**2
+        qq = a**2 - (bb + cc + dd)
+        bc = b * c
+        ad = a * d
+        bd = b * d
+        ac = a * c
+        cd = c * d
+        ab = a * b
+        om[..., 0, 0] = qq + 2 * bb
+        om[..., 0, 1] = 2 * (bc - ad)
+        om[..., 0, 2] = 2 * (bd + ac)
+        om[..., 1, 0] = 2 * (bc + ad)
+        om[..., 1, 1] = qq + 2 * cc
+        om[..., 1, 2] = 2 * (cd - ab)
+        om[..., 2, 0] = 2 * (bd - ac)
+        om[..., 2, 1] = 2 * (cd + ab)
+        om[..., 2, 2] = qq + 2 * dd
+
+        return om
 
     def _outer_dask(
         self, other: Union[Quaternion, Vector3d], chunk_size: int = 20
@@ -501,342 +848,5 @@ class Quaternion(Object3d):
             out = da.stack([x, y, z], axis=-1)
 
         new_chunks = tuple(chunks1[:-1]) + tuple(chunks2[:-1]) + (-1,)
+
         return out.rechunk(new_chunks)
-
-    @classmethod
-    def from_neo_euler(cls, neo_euler: "NeoEuler") -> Quaternion:
-        """Create quaternion(s) from a neo-euler (vector) representation.
-
-        Parameters
-        ----------
-        neo_euler
-            Vector parametrization of quaternions.
-
-        Returns
-        -------
-        quat
-            New quaternions.
-        """
-        s = np.sin(neo_euler.angle / 2)
-        a = np.cos(neo_euler.angle / 2)
-        b = s * neo_euler.axis.x
-        c = s * neo_euler.axis.y
-        d = s * neo_euler.axis.z
-        quat = cls(np.stack([a, b, c, d], axis=-1))
-        return quat
-
-    @classmethod
-    def from_axes_angles(
-        cls,
-        axes: Union[np.ndarray, Vector3d, tuple, list],
-        angles: Union[np.ndarray, tuple, list],
-    ) -> Quaternion:
-        """Create quaternion(s) from axis-angle pair(s).
-
-        Parameters
-        ----------
-        axes
-            The axis of quaternion.
-        angles
-            The angle of quaternion, in radians.
-
-        Returns
-        -------
-        quat
-            Quaternions.
-
-        Examples
-        --------
-        >>> from orix.quaternion import Quaternion
-        >>> quat = Quaternion.from_axes_angles((0, 0, -1), np.pi / 2)
-        >>> quat
-        Quaternion (1,)
-        [[ 0.7071  0.      0.     -0.7071]]
-
-        See Also
-        --------
-        from_neo_euler
-        """
-        axangle = AxAngle.from_axes_angles(axes, angles)
-        return cls.from_neo_euler(axangle)
-
-    # TODO: Remove decorator and **kwargs in 1.0
-    @deprecated_argument("convention", since="0.9", removal="1.0")
-    def to_euler(self, **kwargs) -> np.ndarray:
-        r"""Return the quaternions as Euler angles in the Bunge convention
-        :cite:`rowenhorst2015consistent`.
-
-        Returns
-        -------
-        eu
-            Array of Euler angles in radians, in the ranges
-            :math:`\phi_1 \in [0, 2\pi]`, :math:`\Phi \in [0, \pi]`, and
-            :math:`\phi_1 \in [0, 2\pi]`.
-        """
-        # A.14 from Modelling Simul. Mater. Sci. Eng. 23 (2015) 083501
-        n = self.data.shape[:-1]
-        eu = np.zeros(n + (3,))
-
-        a, b, c, d = self.a, self.b, self.c, self.d
-
-        q03 = a**2 + d**2
-        q12 = b**2 + c**2
-        chi = np.sqrt(q03 * q12)
-
-        # P = 1
-
-        q12_is_zero = q12 == 0
-        if np.sum(q12_is_zero) > 0:
-            alpha = np.arctan2(-2 * a * d, a**2 - d**2)
-            eu[..., 0] = np.where(q12_is_zero, alpha, eu[..., 0])
-            eu[..., 1] = np.where(q12_is_zero, 0, eu[..., 1])
-            eu[..., 2] = np.where(q12_is_zero, 0, eu[..., 2])
-
-        q03_is_zero = q03 == 0
-        if np.sum(q03_is_zero) > 0:
-            alpha = np.arctan2(2 * b * c, b**2 - c**2)
-            eu[..., 0] = np.where(q03_is_zero, alpha, eu[..., 0])
-            eu[..., 1] = np.where(q03_is_zero, np.pi, eu[..., 1])
-            eu[..., 2] = np.where(q03_is_zero, 0, eu[..., 2])
-
-        if np.sum(chi != 0) > 0:
-            not_zero = ~np.isclose(chi, 0)
-            alpha = np.arctan2(
-                np.divide(
-                    b * d - a * c, chi, where=not_zero, out=np.full_like(chi, np.inf)
-                ),
-                np.divide(
-                    -a * b - c * d, chi, where=not_zero, out=np.full_like(chi, np.inf)
-                ),
-            )
-            beta = np.arctan2(2 * chi, q03 - q12)
-            gamma = np.arctan2(
-                np.divide(
-                    a * c + b * d, chi, where=not_zero, out=np.full_like(chi, np.inf)
-                ),
-                np.divide(
-                    c * d - a * b, chi, where=not_zero, out=np.full_like(chi, np.inf)
-                ),
-            )
-            eu[..., 0] = np.where(not_zero, alpha, eu[..., 0])
-            eu[..., 1] = np.where(not_zero, beta, eu[..., 1])
-            eu[..., 2] = np.where(not_zero, gamma, eu[..., 2])
-
-        # Reduce Euler angles to definition range
-        eu[np.abs(eu) < _FLOAT_EPS] = 0
-        eu = np.where(eu < 0, np.mod(eu + 2 * np.pi, (2 * np.pi, np.pi, 2 * np.pi)), eu)
-
-        return eu
-
-    # TODO: Remove decorator, **kwargs, and use of "convention" in 1.0
-    @classmethod
-    @deprecated_argument("convention", "0.9", "1.0", "direction")
-    def from_euler(
-        cls,
-        euler: Union[np.ndarray, tuple, list],
-        direction: str = "lab2crystal",
-        **kwargs,
-    ) -> Quaternion:
-        """Create quaternion(s) from Euler angle set(s) in radians.
-
-        Parameters
-        ----------
-        euler
-            Euler angles in radians in the Bunge convention.
-        direction
-            "lab2crystal" (default) or "crystal2lab". "lab2crystal"
-            is the Bunge convention. If "MTEX" is provided then the
-            direction is "crystal2lab".
-
-        Returns
-        -------
-        quat
-            Quaternions.
-        """
-        direction = direction.lower()
-        if direction == "mtex" or (
-            "convention" in kwargs and kwargs["convention"] == "mtex"
-        ):
-            # MTEX uses bunge but with lab2crystal referencing:
-            # see - https://mtex-toolbox.github.io/MTEXvsBungeConvention.html
-            # and orix issue #215
-            direction = "crystal2lab"
-
-        directions = ["lab2crystal", "crystal2lab"]
-
-        # processing directions
-        if direction not in directions:
-            raise ValueError(
-                f"The chosen direction is not one of the allowed options {directions}"
-            )
-
-        euler = np.asarray(euler)
-        if np.any(np.abs(euler) > 4 * np.pi):
-            warnings.warn(
-                "Angles are assumed to be in radians, but degrees might have been "
-                "passed."
-            )
-        n = euler.shape[:-1]
-        alpha, beta, gamma = euler[..., 0], euler[..., 1], euler[..., 2]
-
-        # Uses A.5 & A.6 from Modelling Simul. Mater. Sci. Eng. 23
-        # (2015) 083501
-        sigma = 0.5 * np.add(alpha, gamma)
-        delta = 0.5 * np.subtract(alpha, gamma)
-        c = np.cos(beta / 2)
-        s = np.sin(beta / 2)
-
-        # Using P = 1 from A.6
-        q = np.zeros(n + (4,))
-        q[..., 0] = c * np.cos(sigma)
-        q[..., 1] = -s * np.cos(delta)
-        q[..., 2] = -s * np.sin(delta)
-        q[..., 3] = -c * np.sin(sigma)
-
-        for i in [1, 2, 3, 0]:  # flip the zero element last
-            q[..., i] = np.where(q[..., 0] < 0, -q[..., i], q[..., i])
-
-        quat = cls(q)
-
-        if direction == "crystal2lab":
-            quat = ~quat
-
-        return quat
-
-    def to_matrix(self) -> np.ndarray:
-        """Return the quaternions as orientation matrices
-        :cite:`rowenhorst2015consistent`.
-
-        Returns
-        -------
-        om
-            Array of orientation matrices.
-
-        Examples
-        --------
-        >>> from orix.quaternion import Quaternion
-        >>> rot = Quaternion([1, 0, 0, 0])
-        >>> np.allclose(rot.to_matrix(), np.eye(3))
-        True
-        >>> rot = Quaternion([0, 1, 0, 0])
-        >>> np.allclose(rot.to_matrix(), np.diag([1, -1, -1]))
-        True
-        """
-        a, b, c, d = self.a, self.b, self.c, self.d
-        om = np.zeros(self.shape + (3, 3))
-
-        bb = b**2
-        cc = c**2
-        dd = d**2
-        qq = a**2 - (bb + cc + dd)
-        bc = b * c
-        ad = a * d
-        bd = b * d
-        ac = a * c
-        cd = c * d
-        ab = a * b
-        om[..., 0, 0] = qq + 2 * bb
-        om[..., 0, 1] = 2 * (bc - ad)
-        om[..., 0, 2] = 2 * (bd + ac)
-        om[..., 1, 0] = 2 * (bc + ad)
-        om[..., 1, 1] = qq + 2 * cc
-        om[..., 1, 2] = 2 * (cd - ab)
-        om[..., 2, 0] = 2 * (bd - ac)
-        om[..., 2, 1] = 2 * (cd + ab)
-        om[..., 2, 2] = qq + 2 * dd
-
-        return om
-
-    @classmethod
-    def from_matrix(cls, matrix: Union[np.ndarray, tuple, list]) -> Quaternion:
-        """Return quaternions from the orientation matrices
-        :cite:`rowenhorst2015consistent`.
-
-        Parameters
-        ----------
-        matrix
-            Array of orientation matrices.
-
-        Returns
-        -------
-        quat
-            Quaternions.
-
-        Examples
-        --------
-        >>> from orix.quaternion import Quaternion
-        >>> rot = Quaternion.from_matrix(np.eye(3))
-        >>> np.allclose(rot.data, [1, 0, 0, 0])
-        True
-        >>> rot = Quaternion.from_matrix(np.diag([1, -1, -1]))
-        >>> np.allclose(rot.data, [0, 1, 0, 0])
-        True
-        """
-        om = np.atleast_3d(matrix)
-        quat = np.zeros(om.shape[:-2] + (4,))
-
-        # Compute quaternion components
-        q0_almost = 1 + om[..., 0, 0] + om[..., 1, 1] + om[..., 2, 2]
-        q1_almost = 1 + om[..., 0, 0] - om[..., 1, 1] - om[..., 2, 2]
-        q2_almost = 1 - om[..., 0, 0] + om[..., 1, 1] - om[..., 2, 2]
-        q3_almost = 1 - om[..., 0, 0] - om[..., 1, 1] + om[..., 2, 2]
-        quat[..., 0] = 0.5 * np.sqrt(np.where(q0_almost < _FLOAT_EPS, 0, q0_almost))
-        quat[..., 1] = 0.5 * np.sqrt(np.where(q1_almost < _FLOAT_EPS, 0, q1_almost))
-        quat[..., 2] = 0.5 * np.sqrt(np.where(q2_almost < _FLOAT_EPS, 0, q2_almost))
-        quat[..., 3] = 0.5 * np.sqrt(np.where(q3_almost < _FLOAT_EPS, 0, q3_almost))
-
-        # Modify component signs if necessary
-        quat[..., 1] = np.where(
-            om[..., 2, 1] < om[..., 1, 2], -quat[..., 1], quat[..., 1]
-        )
-        quat[..., 2] = np.where(
-            om[..., 0, 2] < om[..., 2, 0], -quat[..., 2], quat[..., 2]
-        )
-        quat[..., 3] = np.where(
-            om[..., 1, 0] < om[..., 0, 1], -quat[..., 3], quat[..., 3]
-        )
-
-        return cls(quat).unit  # Normalized
-
-    @classmethod
-    def random(cls, shape: Union[int, tuple] = (1,)) -> Quaternion:
-        """Return uniformly distributed Quaternions.
-
-        Parameters
-        ----------
-        shape
-            The shape of the required object.
-
-        Returns
-        -------
-        quat
-            Quaternions.
-        """
-        shape = (shape,) if isinstance(shape, int) else shape
-        n = int(np.prod(shape))
-        quats = []
-        while len(quats) < n:
-            r = np.random.uniform(-1, 1, (3 * n, cls.dim))
-            r2 = np.sum(np.square(r), axis=1)
-            r = r[np.logical_and(1e-9**2 < r2, r2 <= 1)]
-            quats += list(r)
-        return cls(np.array(quats[:n])).reshape(*shape)
-
-    @classmethod
-    def identity(cls, shape: Union[int, tuple] = (1,)) -> Quaternion:
-        """Create identity quaternions.
-
-        Parameters
-        ----------
-        shape
-            The shape out of which to construct identity quaternions.
-
-        Returns
-        -------
-        rot
-            Identity quaternions.
-        """
-        shape = (shape,) if isinstance(shape, int) else shape
-        data = np.zeros(shape + (4,))
-        data[..., 0] = 1
-        return cls(data)

--- a/orix/quaternion/rotation.py
+++ b/orix/quaternion/rotation.py
@@ -30,6 +30,9 @@ from scipy.special import hyp0f1
 from orix.quaternion import Quaternion
 from orix.vector import Vector3d
 
+# Used to round values below 1e-16 to zero
+_FLOAT_EPS = np.finfo(float).eps
+
 
 class Rotation(Quaternion):
     r"""Transformations of three-dimensional space, leaving the origin in
@@ -74,50 +77,83 @@ class Rotation(Quaternion):
         if isinstance(data, Rotation):
             self.improper = data.improper
         with np.errstate(divide="ignore", invalid="ignore"):
-            self.data = self.data / self.norm[..., np.newaxis]
+            self.data /= self.norm[..., np.newaxis]
+
+    @property
+    def improper(self) -> np.ndarray:
+        """Return ``True`` for improper rotations and ``False``
+        otherwise.
+        """
+        return self._data[..., -1].astype(bool)
+
+    @improper.setter
+    def improper(self, value: np.ndarray):
+        self._data[..., -1] = value
+
+    @property
+    def axis(self) -> Vector3d:
+        """Return the axes of rotation."""
+        axis = Vector3d(np.stack((self.b, self.c, self.d), axis=-1))
+        a_is_zero = self.a < -1e-6
+        axis[a_is_zero] = -axis[a_is_zero]
+        norm_is_zero = axis.norm == 0
+        axis[norm_is_zero] = Vector3d.zvector() * np.sign(self.a[norm_is_zero].data)
+        axis.data /= axis.norm[..., np.newaxis]
+        return axis
+
+    @property
+    def angle(self) -> np.ndarray:
+        """Return the angles of rotation."""
+        return 2 * np.nan_to_num(np.arccos(np.abs(self.a)))
+
+    @property
+    def antipodal(self) -> Rotation:
+        """Return this and the antipodally equivalent rotations."""
+        r = self.__class__(np.stack([self.data, -self.data]))
+        r.improper = self.improper
+        return r
 
     def __mul__(
         self, other: Union[Rotation, Quaternion, Vector3d, np.ndarray, int, list]
     ):
         if isinstance(other, Rotation):
-            quat = Quaternion(self) * Quaternion(other)
-            rot = other.__class__(quat)
-            i = np.logical_xor(self.improper, other.improper)
-            rot.improper = i
-            return rot
+            q = Quaternion(self) * Quaternion(other)
+            r = other.__class__(q)
+            r.improper = np.logical_xor(self.improper, other.improper)
+            return r
         if isinstance(other, Quaternion):
-            quat = Quaternion(self) * other
-            return quat
+            q = Quaternion(self) * other
+            return q
         if isinstance(other, Vector3d):
-            vec = Quaternion(self) * other
+            v = Quaternion(self) * other
             improper = (self.improper * np.ones(other.shape)).astype(bool)
-            vec[improper] = -vec[improper]
-            return vec
+            v[improper] = -v[improper]
+            return v
         if isinstance(other, int) or isinstance(other, list):  # has to plus/minus 1
             other = np.atleast_1d(other).astype(int)
         if isinstance(other, np.ndarray):
             assert np.all(
                 abs(other) == 1
             ), "Rotations can only be multiplied by 1 or -1"
-            rot = Rotation(self.data)
-            rot.improper = np.logical_xor(self.improper, other == -1)
-            return rot
+            r = Rotation(self.data)
+            r.improper = np.logical_xor(self.improper, other == -1)
+            return r
         return NotImplemented
 
     def __neg__(self) -> Rotation:
-        rot = self.__class__(self.data)
-        rot.improper = np.logical_not(self.improper)
-        return rot
+        r = self.__class__(self.data)
+        r.improper = np.logical_not(self.improper)
+        return r
 
     def __getitem__(self, key) -> Rotation:
-        rot = super().__getitem__(key)
-        rot.improper = self.improper[key]
-        return rot
+        r = super().__getitem__(key)
+        r.improper = self.improper[key]
+        return r
 
     def __invert__(self) -> Rotation:
-        rot = super().__invert__()
-        rot.improper = self.improper
-        return rot
+        r = super().__invert__()
+        r.improper = self.improper
+        return r
 
     def __eq__(self, other: Union[Any, Rotation]) -> bool:
         """Check if Rotation objects are equal by their shape and values."""
@@ -131,6 +167,184 @@ class Rotation(Quaternion):
             return True
         else:
             return False
+
+    @classmethod
+    def from_neo_euler(cls, neo_euler: "NeoEuler") -> Rotation:
+        """Create rotations(s) from a neo-euler (vector) representation.
+
+        Parameters
+        ----------
+        neo_euler
+            Vector parametrization of quaternions.
+
+        Returns
+        -------
+        r
+            Rotation(s).
+        """
+        return super().from_neo_euler(neo_euler)
+
+    @classmethod
+    def from_axes_angles(
+        cls,
+        axes: Union[np.ndarray, Vector3d, tuple, list],
+        angles: Union[np.ndarray, tuple, list],
+    ) -> Rotation:
+        """Create rotation(s) from axis-angle pair(s).
+
+        Parameters
+        ----------
+        axes
+            Rotation axes.
+        angles
+            Rotation angles in radians.
+
+        Returns
+        -------
+        r
+            Rotation(s).
+
+        Examples
+        --------
+        >>> from orix.quaternion import Rotation
+        >>> r = Rotation.from_axes_angles((0, 0, -1), np.pi / 2)
+        >>> r
+        Rotation (1,)
+        [[ 0.7071  0.      0.     -0.7071]]
+
+        See Also
+        --------
+        from_neo_euler
+        """
+        return super().from_axes_angles(axes, angles)
+
+    # TODO: Remove **kwargs in 1.0.
+    # Deprication decorator is implemented in Quaternion
+    @classmethod
+    def from_euler(
+        cls,
+        euler: Union[np.ndarray, tuple, list],
+        direction: str = "lab2crystal",
+        **kwargs,
+    ) -> Rotation:
+        """Create rotation(s) from Euler angle set(s) in radians
+        :cite:`rowenhorst2015consistent`.
+
+        Parameters
+        ----------
+        euler
+            Euler angles in radians in the Bunge convention.
+        direction
+            Direction of the transformation, either ``"lab2crystal"``
+            (default) or the inverse, ``"crystal2lab"``. The former is
+            the Bunge convention. Passing ``"MTEX"`` equals the latter.
+
+        Returns
+        -------
+        r
+            Rotation(s).
+        """
+        r = super().from_euler(euler=euler, direction=direction, **kwargs)
+        r.improper = np.zeros(euler.shape[:-1])
+        return r
+
+    @classmethod
+    def from_matrix(cls, matrix: Union[np.ndarray, tuple, list]) -> Rotation:
+        """Return rotations from the orientation matrices
+        :cite:`rowenhorst2015consistent`.
+
+        Parameters
+        ----------
+        matrix
+            Sequence of orientation matrices with the last two
+            dimensions of shape ``(3, 3)``.
+
+        Returns
+        -------
+        r
+            Rotations.
+
+        Examples
+        --------
+        >>> from orix.quaternion import Rotation
+        >>> r = Rotation.from_matrix([np.identity(3), np.diag([1, -1, -1])])
+        >>> r
+        Rotation (2,)
+        [[1. 0. 0. 0.]
+         [0. 1. 0. 0.]]
+        """
+        return super().from_matrix(matrix)
+
+    @classmethod
+    def random(cls, shape: Union[int, tuple] = (1,)) -> Rotation:
+        """Return random rotations.
+
+        Parameters
+        ----------
+        shape
+            Shape of the rotation instance.
+
+        Returns
+        -------
+        r
+            Rotations.
+        """
+        return super().random(shape)
+
+    @classmethod
+    def identity(cls, shape: Union[int, tuple] = (1,)) -> Rotation:
+        """Return identity rotations.
+
+        Parameters
+        ----------
+        shape
+            Shape of the rotation instance.
+
+        Returns
+        -------
+        r
+            Identity rotations.
+        """
+        return super().identity(shape)
+
+    @classmethod
+    def random_vonmises(
+        cls,
+        shape: Union[int, tuple] = (1,),
+        alpha: float = 1.0,
+        reference: Union[list, tuple, Rotation] = (1, 0, 0, 0),
+    ) -> Rotation:
+        """Return random rotations with a simplified Von Mises-Fisher
+        distribution.
+
+        Parameters
+        ----------
+        shape
+            The shape of the required object.
+        alpha
+            Parameter for the VM-F distribution. Lower values lead to
+            "looser" distributions.
+        reference
+            The center of the distribution.
+
+        Returns
+        -------
+        r
+            Rotations.
+        """
+        shape = (shape,) if isinstance(shape, int) else shape
+        reference = Rotation(reference)
+        n = int(np.prod(shape))
+        sample_size = int(alpha) * n
+        r = []
+        f_max = von_mises(reference, alpha, reference)
+        while len(r) < n:
+            r_i = cls.random(sample_size)
+            f = von_mises(r_i, alpha, reference)
+            x = np.random.rand(sample_size)
+            r_i = r_i[x * f_max < f]
+            r += list(r_i)
+        return cls.stack(r[:n]).reshape(*shape)
 
     def unique(
         self,
@@ -164,7 +378,7 @@ class Rotation(Quaternion):
 
         Returns
         -------
-        rot
+        r
             Unique rotations.
         idx_sort
             Indices of the flattened rotations where the unique entries
@@ -175,29 +389,24 @@ class Rotation(Quaternion):
         """
         if len(self.data) == 0:
             return self.__class__(self.data)
-        rotation = self.flatten()
+        r = self.flatten()
+
         if antipodal:
-            abcd = rotation._differentiators()
+            abcd = r._differentiators()
         else:
-            abcd = np.stack(
-                [
-                    rotation.a,
-                    rotation.b,
-                    rotation.c,
-                    rotation.d,
-                    rotation.improper,
-                ],
-                axis=-1,
-            ).round(12)
+            abcd = np.stack([r.a, r.b, r.c, r.d, r.improper], axis=-1).round(12)
+
         _, idx, inv = np.unique(abcd, axis=0, return_index=True, return_inverse=True)
         idx_argsort = np.argsort(idx)
         idx_sort = idx[idx_argsort]
-        # build inverse index map
+
+        # Build inverse index map
         inv_map = np.empty_like(idx_argsort)
         inv_map[idx_argsort] = np.arange(idx_argsort.size)
         inv = inv_map[inv]
-        dat = rotation[idx_sort]
-        dat.improper = rotation.improper[idx_sort]
+        dat = r[idx_sort]
+        dat.improper = r.improper[idx_sort]
+
         if return_index and return_inverse:
             return dat, idx_sort, inv
         elif return_index and not return_inverse:
@@ -206,30 +415,6 @@ class Rotation(Quaternion):
             return dat, inv
         else:
             return dat
-
-    def _differentiators(self) -> np.ndarray:
-        a = self.a
-        b = self.b
-        c = self.c
-        d = self.d
-        i = self.improper
-        abcd = np.stack(
-            (
-                a**2,
-                b**2,
-                c**2,
-                d**2,
-                a * b,
-                a * c,
-                a * d,
-                b * c,
-                b * d,
-                c * d,
-                i,
-            ),
-            axis=-1,
-        ).round(12)
-        return abcd
 
     def angle_with(self, other: Rotation) -> np.ndarray:
         """Return the angles of rotation transforming the rotations to
@@ -317,7 +502,7 @@ class Rotation(Quaternion):
 
         Returns
         -------
-        rot
+        r
             Outer rotation products.
         """
         if lazy:
@@ -328,33 +513,28 @@ class Rotation(Quaternion):
                     da.store(darr, arr)
             else:
                 da.store(darr, arr)
-            rot = other.__class__(arr)
+            r = other.__class__(arr)
         else:
-            rot = super().outer(other)
+            r = super().outer(other)
 
-        if isinstance(rot, Rotation):
-            rot.improper = np.logical_xor.outer(self.improper, other.improper)
-        elif isinstance(rot, Vector3d):
-            rot[self.improper] = -rot[self.improper]
+        if isinstance(r, Rotation):
+            r.improper = np.logical_xor.outer(self.improper, other.improper)
+        elif isinstance(r, Vector3d):
+            r[self.improper] = -r[self.improper]
 
-        return rot
+        return r
 
     def flatten(self) -> Rotation:
-        """A new object with the same data in a single column."""
-        rot = super().flatten()
-        rot.improper = self.improper.T.flatten().T
-        return rot
+        """Return a new rotation instance collapsed into one dimension.
 
-    @property
-    def improper(self) -> np.ndarray:
-        """Return ``True`` for improper rotations and ``False``
-        otherwise.
+        Returns
+        -------
+        r
+            Rotations collapsed into one dimension.
         """
-        return self._data[..., -1].astype(bool)
-
-    @improper.setter
-    def improper(self, value: np.ndarray):
-        self._data[..., -1] = value
+        r = super().flatten()
+        r.improper = self.improper.T.flatten().T
+        return r
 
     def dot_outer(self, other: Rotation) -> np.ndarray:
         """Return the outer dot products of the rotations and the other
@@ -379,91 +559,60 @@ class Rotation(Quaternion):
             dot_products[self.improper] = 0
         return dot_products
 
-    # TODO: Remove **kwargs in 1.0.
-    # Deprication decorator is implemented in Quaternion
-    @classmethod
-    def from_euler(
-        cls, euler: np.ndarray, direction: str = "lab2crystal", **kwargs
-    ) -> Rotation:
-        """Create a rotation from an array of Euler angles in radians.
-
-        Parameters
-        ----------
-        euler
-            Euler angles in radians in the Bunge convention.
-        direction
-            "lab2crystal" (default) or "crystal2lab". "lab2crystal"
-            is the Bunge convention. If "MTEX" is provided then the
-            direction is "crystal2lab".
-        """
-        euler = np.asarray(euler)
-        rot = super().from_euler(euler=euler, direction=direction, **kwargs)
-
-        rot.improper = np.zeros(euler.shape[:-1])
-
-        return rot
-
-    @property
-    def axis(self) -> Vector3d:
-        """Return the axes of rotation."""
-        axis = Vector3d(np.stack((self.b, self.c, self.d), axis=-1))
-        a_is_zero = self.a < -1e-6
-        axis[a_is_zero] = -axis[a_is_zero]
-        norm_is_zero = axis.norm == 0
-        axis[norm_is_zero] = Vector3d.zvector() * np.sign(self.a[norm_is_zero].data)
-        axis.data = axis.data / axis.norm[..., np.newaxis]
-        return axis
-
-    @property
-    def angle(self) -> np.ndarray:
-        """Return the angles of rotation."""
-        return 2 * np.nan_to_num(np.arccos(np.abs(self.a)))
-
-    @classmethod
-    def random_vonmises(
-        cls,
-        shape: Union[int, tuple] = (1,),
-        alpha: float = 1.0,
-        reference: Union[list, tuple, Rotation] = (1, 0, 0, 0),
-    ) -> Rotation:
-        """Return random rotations with a simplified Von Mises-Fisher
-        distribution.
-
-        Parameters
-        ----------
-        shape
-            The shape of the required object.
-        alpha
-            Parameter for the VM-F distribution. Lower values lead to
-            "looser" distributions.
-        reference
-            The center of the distribution.
+    def to_matrix(self) -> np.ndarray:
+        """Return the rotations as orientation matrices
+        :cite:`rowenhorst2015consistent`.
 
         Returns
         -------
-        rot
-            Rotations.
-        """
-        shape = (shape,) if isinstance(shape, int) else shape
-        reference = Rotation(reference)
-        n = int(np.prod(shape))
-        sample_size = int(alpha) * n
-        rotations = []
-        f_max = von_mises(reference, alpha, reference)
-        while len(rotations) < n:
-            rotation = cls.random(sample_size)
-            f = von_mises(rotation, alpha, reference)
-            x = np.random.rand(sample_size)
-            rotation = rotation[x * f_max < f]
-            rotations += list(rotation)
-        return cls.stack(rotations[:n]).reshape(*shape)
+        om
+            Array of orientation matrices.
 
-    @property
-    def antipodal(self) -> Rotation:
-        """Return this and the antipodally equivalent rotations."""
-        rot = self.__class__(np.stack([self.data, -self.data]))
-        rot.improper = self.improper
-        return rot
+        Examples
+        --------
+        >>> from orix.quaternion import Rotation
+        >>> r = Rotation([[1, 0, 0, 0], [2, 0, 0, 0]])
+        >>> np.allclose(r.to_matrix(), np.eye(3))
+        True
+        >>> r = Rotation([[0, 1, 0, 0], [0, 2, 0, 0]])
+        >>> np.allclose(r.to_matrix(), np.diag([1, -1, -1]))
+        True
+        """
+        return super().to_matrix()
+
+    # TODO: Remove **kwargs in 1.0
+    def to_euler(self, **kwargs) -> np.ndarray:
+        r"""Return the rotations as Euler angles in the Bunge convention
+        :cite:`rowenhorst2015consistent`.
+
+        Returns
+        -------
+        eu
+            Array of Euler angles in radians, in the ranges
+            :math:`\phi_1 \in [0, 2\pi]`, :math:`\Phi \in [0, \pi]`, and
+            :math:`\phi_1 \in [0, 2\pi]`.
+        """
+        return super().to_euler(**kwargs)
+
+    def _differentiators(self) -> np.ndarray:
+        a = self.a
+        b = self.b
+        c = self.c
+        d = self.d
+        i = self.improper
+        # fmt: off
+        abcd = np.stack(
+            (
+                a ** 2, b ** 2, c ** 2, d ** 2,
+                a * b, a * c, a * d,
+                b * c, b * d,
+                c * d,
+                i,
+            ),
+            axis=-1,
+        ).round(12)
+        # fmt: on
+        return abcd
 
 
 def von_mises(
@@ -482,7 +631,7 @@ def von_mises(
 
     Returns
     -------
-    rot
+    r
         Rotations.
 
     Notes

--- a/orix/tests/conftest.py
+++ b/orix/tests/conftest.py
@@ -36,6 +36,11 @@ def rotations():
     return Rotation([(2, 4, 6, 8), (-1, -3, -5, -7)])
 
 
+@pytest.fixture()
+def eu():
+    return np.random.rand(10, 3)
+
+
 # TODO: Exchange for a multiphase header (change `phase_id` accordingly)
 ANGFILE_TSL_HEADER = (
     "# TEM_PIXperUM          1.000000\n"

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -17,23 +17,23 @@
 # along with orix.  If not, see <http://www.gnu.org/licenses/>.
 
 import dask.array as da
+from diffpy.structure.spacegroups import sg225
 import numpy as np
 import pytest
 
 from orix.base import DimensionError
 from orix.quaternion import Quaternion
-from orix.vector import Vector3d
+from orix.vector import AxAngle, Vector3d
 
-# fmt: off
-values = [
+
+@pytest.fixture(
+    params=[
+        # fmt: off
     (0.707,  0.0,  0.0, 0.707),
     (0.5  , -0.5, -0.5,   0.5),
     (0.0  ,  0.0,  0.0,   1.0),
     (1.0  ,  1.0,  1.0,   1.0),
-    (
-        (0.5, -0.5, -0.5, 0.5),
-        (0.0,  0.0,  0.0, 1.0),
-    ),
+    ((0.5, -0.5, -0.5, 0.5), (0.0,  0.0,  0.0, 1.0)),
     Quaternion(
         [
             [(0.0, 0.0, 0.0, 1.0), (0.707, 0.0, 0.0, 0.707)],
@@ -41,23 +41,9 @@ values = [
         ]
     ),
     np.array((4, 3, 2, 1)),
-]
-singles = [
-    (0.881, 0.665, 0.123, 0.517),
-    (0.111, 0.222, 0.333, 0.444),
-    (
-        (1, 0,  0.5,  0),
-        (3, 1, -1  , -2)
-    ),
-    [
-        [[0.343  ,  0.343,  0    , -0.333], [-7, -8, -9, -10]],
-        [[0.00001, -0.0001, 0.001, -0.01 ], [ 0,  0,  0,   0]],
-    ],
-]
-# fmt: on
-
-
-@pytest.fixture(params=values)
+        # fmt: on
+    ]
+)
 def quaternion(request):
     return Quaternion(request.param)
 
@@ -67,24 +53,39 @@ def identity():
     return Quaternion((1, 0, 0, 0))
 
 
-@pytest.fixture(params=singles)
+@pytest.fixture(
+    params=[
+        # fmt: off
+    (0.881, 0.665, 0.123, 0.517),
+    (0.111, 0.222, 0.333, 0.444),
+    ((1, 0,  0.5,  0), (3, 1, -1  , -2)),
+    [
+        [[0.343  ,  0.343,  0    , -0.333], [-7, -8, -9, -10]],
+        [[0.00001, -0.0001, 0.001, -0.01 ], [ 0,  0,  0,   0]],
+    ],
+        # fmt: on
+    ]
+)
 def something(request):
     return Quaternion(request.param)
 
 
-@pytest.mark.parametrize("input_length", [1, 2, 3, 5, 6, 8])
-def test_init(input_length):
-    with pytest.raises(DimensionError):
-        Quaternion(tuple(range(input_length)))
+@pytest.fixture()
+def eu():
+    return np.random.rand(10, 3)
 
 
 class TestQuaternion:
+    @pytest.mark.parametrize("input_length", [1, 2, 3, 5, 6, 8])
+    def test_init(self, input_length):
+        with pytest.raises(DimensionError):
+            Quaternion(tuple(range(input_length)))
+
     def test_neg(self, quaternion):
-        assert np.allclose((-quaternion).data, -(quaternion.data))
+        assert np.allclose((-quaternion).data, (-quaternion.data))
 
     def test_norm(self, quaternion):
-        q = quaternion
-        assert np.allclose(q.norm, (q.data**2).sum(axis=-1) ** 0.5)
+        assert np.allclose(quaternion.norm, (quaternion.data**2).sum(axis=-1) ** 0.5)
 
     def test_unit(self, quaternion):
         assert np.allclose(quaternion.unit.norm, 1)
@@ -282,3 +283,173 @@ class TestQuaternion:
         other = np.random.rand(7, 3)
         with pytest.raises(TypeError, match="Other must be Quaternion or Vector3d"):
             q._outer_dask(other)
+
+
+class TestToFromEuler:
+    """These tests address .to_euler() and .from_euler()."""
+
+    def test_to_from_euler(self, eu):
+        """Checks that going euler2quat2euler gives no change."""
+        q = Quaternion.from_euler(eu)
+        e2 = q.to_euler()
+        assert np.allclose(eu, e2.data)
+
+    def test_mtex(self, eu):
+        _ = Quaternion.from_euler(eu, direction="mtex")
+
+    def test_direction_values(self, eu):
+        q_mtex = Quaternion.from_euler(eu, direction="mtex")
+        q_c2l = Quaternion.from_euler(eu, direction="crystal2lab")
+        q_l2c = Quaternion.from_euler(eu, direction="lab2crystal")
+        q_default = Quaternion.from_euler(eu)
+        assert np.allclose(q_default.data, q_l2c.data)
+        assert np.allclose(q_mtex.data, q_c2l.data)
+        assert np.allclose((q_l2c * q_c2l).data, [1, 0, 0, 0])
+
+    def test_direction_kwarg(self, eu):
+        _ = Quaternion.from_euler(eu, direction="lab2crystal")
+
+    def test_direction_kwarg_dumb(self, eu):
+        with pytest.raises(ValueError, match="The chosen direction is not one of "):
+            _ = Quaternion.from_euler(eu, direction="dumb_direction")
+
+    def test_edge_cases_to_euler(self):
+        x = np.sqrt(1 / 2)
+        q = Quaternion(np.asarray([x, 0, 0, x]))
+        _ = q.to_euler()
+        q = Quaternion(np.asarray([0, x, 0, 0]))
+        _ = q.to_euler()
+
+    def test_passing_degrees_warns(self):
+        with pytest.warns(UserWarning, match="Angles are assumed to be in radians, "):
+            q = Quaternion.from_euler([90, 0, 0])
+            assert np.allclose(q.data, [0.5253, 0, 0, -0.8509], atol=1e-4)
+
+    # TODO: Remove in 1.0
+    def test_from_euler_warns(self, eu):
+        """Quaternion.from_euler() warns only when "convention" argument
+        is passed.
+        """
+        with pytest.warns(None) as record:
+            _ = Quaternion.from_euler(eu)
+        assert len(record) == 0
+
+        msg = (
+            r"Argument `convention` is deprecated and will be removed in version 1.0. "
+            r"To avoid this warning, please do not use `convention`. "
+            r"Use `direction` instead. See the documentation of `from_euler\(\)` for "
+            "more details."
+        )
+        with pytest.warns(np.VisibleDeprecationWarning, match=msg):
+            _ = Quaternion.from_euler(eu, convention="whatever")
+
+    # TODO: Remove in 1.0
+    def test_from_euler_convention_mtex(self, eu):
+        """Passing convention="mtex" to Quaternion.from_euler() works but
+        warns.
+        """
+        quat1 = Quaternion.from_euler(eu, direction="crystal2lab")
+        with pytest.warns(np.VisibleDeprecationWarning, match=r"Argument `convention`"):
+            quat2 = Quaternion.from_euler(eu, convention="mtex")
+        assert np.allclose(quat1.data, quat2.data)
+
+    # TODO: Remove in 1.0
+    def test_to_euler_convention_warns(self, eu):
+        """Quaternion.to_euler() warns only when "convention" argument is
+        passed.
+        """
+        quat1 = Quaternion.from_euler(eu)
+
+        with pytest.warns(None) as record:
+            quat2 = quat1.to_euler()
+        assert len(record) == 0
+
+        msg = (
+            r"Argument `convention` is deprecated and will be removed in version 1.0. "
+            r"To avoid this warning, please do not use `convention`. "
+            r"See the documentation of `to_euler\(\)` for more details."
+        )
+        with pytest.warns(np.VisibleDeprecationWarning, match=msg):
+            quat3 = quat1.to_euler(convention="whatever")
+        assert np.allclose(quat2, quat3)
+
+
+class TestFromToMatrix:
+    def test_to_matrix(self):
+        q = Quaternion([[1, 0, 0, 0], [3, 0, 0, 0], [0, 1, 0, 0], [0, 2, 0, 0]])
+        om = np.array(
+            [np.eye(3), np.eye(3), np.diag([1, -1, -1]), np.diag([1, -1, -1])]
+        )
+        # Shapes are handled correctly
+        assert np.allclose(q.reshape(2, 2).unit.to_matrix(), om.reshape(2, 2, 3, 3))
+
+        q2 = Quaternion(
+            [
+                [0.1, 0.2, 0.3, 0.4],
+                [0.5, 0.6, 0.7, 0.8],
+                [0.9, 0.91, 0.92, 0.93],
+                [1, 2, 3, 4],
+            ]
+        ).unit
+        om_from_q2 = q2.to_matrix()
+        # Inverse equal to transpose
+        assert all(np.allclose(np.linalg.inv(i), i.T) for i in om_from_q2)
+        # Cross product of any two rows gives the third
+        assert all(np.allclose(np.cross(i[:, 0], i[:, 1]), i[:, 2]) for i in om_from_q2)
+        # Sum of squares of any column or row equals unity
+        assert np.allclose(np.sum(np.square(om_from_q2), axis=1), 1)  # Rows
+        assert np.allclose(np.sum(np.square(om_from_q2), axis=2), 1)  # Columns
+
+    def test_from_matrix(self):
+        q = Quaternion([[1, 0, 0, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 1, 0, 0]])
+        ident = np.identity(3)
+        rot_180x = np.diag([1, -1, -1])
+        om = np.array([ident, 2 * ident, rot_180x, 2 * rot_180x])
+        assert np.allclose(Quaternion.from_matrix(om).data, q.data)
+        assert np.allclose(
+            Quaternion.from_matrix(om.reshape((2, 2, 3, 3))).data, q.reshape(2, 2).data
+        )
+
+    def test_from_to_matrix(self):
+        ident = np.identity(3)
+        rot_180x = np.diag([1, -1, -1])
+        assert np.allclose(
+            Quaternion.from_matrix(
+                [ident, 2 * ident, rot_180x, 2 * rot_180x]
+            ).to_matrix(),
+            [ident, ident, rot_180x, rot_180x],
+        )
+
+    def test_from_euler_to_matrix_from_matrix(self, eu):
+        q = Quaternion.from_euler(eu.reshape((5, 2, 3)))
+        assert np.allclose(Quaternion.from_matrix(q.to_matrix()).data, q.data)
+
+    def test_from_matrix_to_euler_from_euler_to_matrix(self, eu):
+        rot_180x = np.diag([1, -1, -1])
+        rot_180y = np.diag([-1, 1, -1])
+        rot_180z = np.diag([-1, -1, 1])
+
+        om1 = np.array([rot_180x, rot_180y, rot_180z])
+        quat1 = Quaternion.from_matrix(om1)
+        eu = quat1.to_euler()
+        quat2 = Quaternion.from_euler(eu)
+        om2 = quat2.to_matrix()
+
+        assert np.allclose(om2, om1)
+
+    def test_get_rotation_matrix_from_diffpy(self):
+        """Checking that getting rotation matrices from diffpy.structure
+        works without issue.
+        """
+        q = Quaternion.from_matrix([i.R for i in sg225.symop_list])
+        assert not np.isnan(q.data).any()
+
+
+class TestFromAxesAngles:
+    """These tests address Quaternion.from_axes_angles()."""
+
+    def test_from_axes_angles(self, rotations):
+        axangle = AxAngle.from_rotation(rotations)
+        quat2 = Quaternion.from_neo_euler(axangle)
+        quat3 = Quaternion.from_axes_angles(axangle.axis.data, axangle.angle)
+        assert np.allclose(quat2.data, quat3.data)

--- a/orix/tests/quaternion/test_quaternion.py
+++ b/orix/tests/quaternion/test_quaternion.py
@@ -70,11 +70,6 @@ def something(request):
     return Quaternion(request.param)
 
 
-@pytest.fixture()
-def eu():
-    return np.random.rand(10, 3)
-
-
 class TestQuaternion:
     @pytest.mark.parametrize("input_length", [1, 2, 3, 5, 6, 8])
     def test_init(self, input_length):
@@ -290,9 +285,8 @@ class TestToFromEuler:
 
     def test_to_from_euler(self, eu):
         """Checks that going euler2quat2euler gives no change."""
-        q = Quaternion.from_euler(eu)
-        e2 = q.to_euler()
-        assert np.allclose(eu, e2.data)
+        eu2 = Quaternion.from_euler(eu).to_euler()
+        assert np.allclose(eu, eu2.data)
 
     def test_mtex(self, eu):
         _ = Quaternion.from_euler(eu, direction="mtex")

--- a/orix/tests/quaternion/test_rotation.py
+++ b/orix/tests/quaternion/test_rotation.py
@@ -18,7 +18,6 @@
 
 from math import cos, pi, sin, tan
 
-from diffpy.structure.spacegroups import sg225
 import numpy as np
 import pytest
 
@@ -225,100 +224,6 @@ def test_neg(rotation, i, expected_i):
     rotation.improper = i
     r = -rotation
     assert np.allclose(r.improper, expected_i)
-
-
-@pytest.fixture()
-def e():
-    return np.random.rand(10, 3)
-
-
-class TestToFromEuler:
-    """These tests address .to_euler() and .from_euler()."""
-
-    def test_to_from_euler(self, e):
-        """Checks that going euler2quat2euler gives no change."""
-        r = Rotation.from_euler(e)
-        e2 = r.to_euler()
-        assert np.allclose(e, e2.data)
-
-    def test_mtex(self, e):
-        _ = Rotation.from_euler(e, direction="mtex")
-
-    def test_direction_values(self, e):
-        r_mtex = Rotation.from_euler(e, direction="mtex")
-        r_c2l = Rotation.from_euler(e, direction="crystal2lab")
-        r_l2c = Rotation.from_euler(e, direction="lab2crystal")
-        r_default = Rotation.from_euler(e)
-        assert np.allclose(r_default.data, r_l2c.data)
-        assert np.allclose(r_mtex.data, r_c2l.data)
-        assert np.allclose((r_l2c * r_c2l).angle.data, 0)
-
-    def test_direction_kwarg(self, e):
-        _ = Rotation.from_euler(e, direction="lab2crystal")
-
-    def test_direction_kwarg_dumb(self, e):
-        with pytest.raises(ValueError, match="The chosen direction is not one of "):
-            _ = Rotation.from_euler(e, direction="dumb_direction")
-
-    def test_edge_cases_to_euler(self):
-        x = np.sqrt(1 / 2)
-        q = Rotation(np.asarray([x, 0, 0, x]))
-        _ = q.to_euler()
-        q = Rotation(np.asarray([0, x, 0, 0]))
-        _ = q.to_euler()
-
-    def test_passing_degrees_warns(self):
-        with pytest.warns(UserWarning, match="Angles are assumed to be in radians, "):
-            r = Rotation.from_euler([90, 0, 0])
-            assert np.allclose(r.data, [0.5253, 0, 0, -0.8509], atol=1e-4)
-
-    # TODO: Remove in 1.0
-    def test_from_euler_warns(self, e):
-        """Rotation.from_euler() warns only when "convention" argument
-        is passed.
-        """
-        with pytest.warns(None) as record:
-            _ = Rotation.from_euler(e)
-        assert len(record) == 0
-
-        msg = (
-            r"Argument `convention` is deprecated and will be removed in version 1.0. "
-            r"To avoid this warning, please do not use `convention`. "
-            r"Use `direction` instead. See the documentation of `from_euler\(\)` for "
-            "more details."
-        )
-        with pytest.warns(np.VisibleDeprecationWarning, match=msg):
-            _ = Rotation.from_euler(e, convention="whatever")
-
-    # TODO: Remove in 1.0
-    def test_from_euler_convention_mtex(self, e):
-        """Passing convention="mtex" to Rotation.from_euler() works but
-        warns.
-        """
-        rot1 = Rotation.from_euler(e, direction="crystal2lab")
-        with pytest.warns(np.VisibleDeprecationWarning, match=r"Argument `convention`"):
-            rot2 = Rotation.from_euler(e, convention="mtex")
-        assert np.allclose(rot1.data, rot2.data)
-
-    # TODO: Remove in 1.0
-    def test_to_euler_convention_warns(self, e):
-        """Rotation.to_euler() warns only when "convention" argument is
-        passed.
-        """
-        rot1 = Rotation.from_euler(e)
-
-        with pytest.warns(None) as record:
-            rot2 = rot1.to_euler()
-        assert len(record) == 0
-
-        msg = (
-            r"Argument `convention` is deprecated and will be removed in version 1.0. "
-            r"To avoid this warning, please do not use `convention`. "
-            r"See the documentation of `to_euler\(\)` for more details."
-        )
-        with pytest.warns(np.VisibleDeprecationWarning, match=msg):
-            rot3 = rot1.to_euler(convention="whatever")
-        assert np.allclose(rot2, rot3)
 
 
 @pytest.mark.parametrize(
@@ -605,65 +510,26 @@ def test_random_vonmises(shape, reference):
     assert isinstance(r, Rotation)
 
 
+class TestToFromEuler:
+    def test_from_euler(self, eu):
+        r = Rotation.from_euler(eu)
+        assert isinstance(r, Rotation)
+
+
 class TestFromToMatrix:
-    def test_to_matrix(self):
-        r = Rotation([[1, 0, 0, 0], [3, 0, 0, 0], [0, 1, 0, 0], [0, 2, 0, 0]])
-        om = np.array(
-            [np.eye(3), np.eye(3), np.diag([1, -1, -1]), np.diag([1, -1, -1])]
-        )
-        # Shapes are handled correctly
-        assert np.allclose(r.reshape(2, 2).to_matrix(), om.reshape(2, 2, 3, 3))
-
-        r2 = Rotation(
-            [
-                [0.1, 0.2, 0.3, 0.4],
-                [0.5, 0.6, 0.7, 0.8],
-                [0.9, 0.91, 0.92, 0.93],
-                [1, 2, 3, 4],
-            ]
-        )
-        om_from_r2 = r2.to_matrix()
-        # Inverse equal to transpose
-        assert all(np.allclose(np.linalg.inv(i), i.T) for i in om_from_r2)
-        # Cross product of any two rows gives the third
-        assert all(np.allclose(np.cross(i[:, 0], i[:, 1]), i[:, 2]) for i in om_from_r2)
-        # Sum of squares of any column or row equals unity
-        assert np.allclose(np.sum(np.square(om_from_r2), axis=1), 1)  # Rows
-        assert np.allclose(np.sum(np.square(om_from_r2), axis=2), 1)  # Columns
-
     def test_from_matrix(self):
-        r = Rotation([[1, 0, 0, 0], [3, 0, 0, 0], [0, 1, 0, 0], [0, 2, 0, 0]])
-        om = np.array(
-            [np.eye(3), np.eye(3), np.diag([1, -1, -1]), np.diag([1, -1, -1])]
+        r = Rotation.from_matrix(
+            [np.identity(3), np.diag([1, -1, -1]), 2 * np.diag([1, -1, -1])]
         )
-        assert np.allclose(Rotation.from_matrix(om).data, r.data)
-        assert np.allclose(
-            Rotation.from_matrix(om.reshape((2, 2, 3, 3))).data, r.reshape(2, 2).data
-        )
-
-    def test_from_to_matrix(self):
-        om = np.array(
-            [np.eye(3), np.eye(3), np.diag([1, -1, -1]), np.diag([1, -1, -1])]
-        )
-        assert np.allclose(Rotation.from_matrix(om).to_matrix(), om)
-
-    def test_from_to_matrix2(self, e):
-        r = Rotation.from_euler(e.reshape((5, 2, 3)))
-        assert np.allclose(Rotation.from_matrix(r.to_matrix()).data, r.data)
-
-    def test_get_rotation_matrix_from_diffpy(self):
-        """Checking that getting rotation matrices from diffpy.structure
-        works without issue.
-        """
-        r = Rotation.from_matrix([i.R for i in sg225.symop_list])
-        assert not np.isnan(r.data).any()
+        assert isinstance(r, Rotation)
+        assert np.allclose(r.data, [[1, 0, 0, 0], [0, 1, 0, 0], [0, 1, 0, 0]])
 
 
 class TestFromAxesAngles:
-    """These tests address Rotation.from_axes_angles()."""
-
     def test_from_axes_angles(self, rotations):
         axangle = AxAngle.from_rotation(rotations)
-        rotations2 = Rotation.from_neo_euler(axangle)
-        rotations3 = Rotation.from_axes_angles(axangle.axis.data, axangle.angle)
-        assert np.allclose(rotations2.data, rotations3.data)
+        r1 = Rotation.from_neo_euler(axangle)
+        r2 = Rotation.from_axes_angles(axangle.axis.data, axangle.angle)
+        assert isinstance(r1, Rotation)
+        assert isinstance(r2, Rotation)
+        assert np.allclose(r1.data, r2.data)

--- a/orix/tests/test_vector3d.py
+++ b/orix/tests/test_vector3d.py
@@ -468,7 +468,6 @@ class TestVector3dInversePoleDensityFunction:
                 colorbar=True,
                 hemisphere="test",
             )
-            plt.close(fig)
 
 
 class TestVector3dPoleDensityFunction:


### PR DESCRIPTION
#### Description of the change
* Move tests of `Rotation` methods `from_matrix()`, `from_euler()`, `from_neo_euler()`, `from_axes_angles()`, `to_matrix()` and `to_euler()` to `Quaternion` test file
* Overwrite these methods, inherited from `Quaternion`, in `Rotation` so that they are included in the [API reference list](https://orix.readthedocs.io/en/stable/reference/generated/orix.quaternion.Rotation.html#) of that class with the correct wording and examples (e.g. "Return rotations...", not "Return quaternions...")
* Sort elements in the `Rotation` and `Quaternion` classes in the following order: attributes, dunder (double underscore), classmethods, public methods, private methods

Tests and docs pass on my Ubuntu 22.04 machine. We can continue to debug in #406 if necessary.

#### Progress of the PR
- [x] [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- [x] Unit tests with pytest for all lines
- [x] Clean code style by [running black via pre-commit](https://orix.readthedocs.io/en/latest/contributing.html#code-style)

#### For reviewers
<!-- Don't remove the checklist below. -->
- [ ] The PR title is short, concise, and will make sense 1 year later.
- [ ] New functions are imported in corresponding `__init__.py`.
- [ ] New features, API changes, and deprecations are mentioned in the unreleased
      section in `CHANGELOG.rst`.
- [ ] Contributor(s) are listed correctly in `__credits__` in `orix/__init__.py` and in
      `.zenodo.json`.